### PR TITLE
Allow TTF filepath for function imageDrawText

### DIFF
--- a/source/java/src/org/lucee/extension/image/Image.java
+++ b/source/java/src/org/lucee/extension/image/Image.java
@@ -575,12 +575,12 @@ public class Image extends StructSupport implements Cloneable,Struct {
     	if (attr != null && attr.size()>0) {
 
        	 // font
-       		String font=eng().getCastUtil().toString(attr.get("font","")).toLowerCase().trim();
-       	    if(!eng().getStringUtil().isEmpty(font)) {
-   	    	    font=FontUtil.getFont(font).getFontName();
+       		String fontName=eng().getCastUtil().toString(attr.get("font","")).toLowerCase().trim();
+       	    if(eng().getStringUtil().isEmpty(fontName)) {
+       	    	fontName = "Serif";
        	    }
-       	    else font = "Serif";
-       	    
+			Font font = FontUtil.getFont(fontName);
+
     	 // alpha
     		//float alpha=eng().getCastUtil().toFloatValue(attr.get("alpha",null),1F);
     	    
@@ -610,7 +610,7 @@ public class Image extends StructSupport implements Cloneable,Struct {
     	    boolean underline = eng().getCastUtil().toBooleanValue(attr.get("underline",Boolean.FALSE));
     	    
     	    AttributedString as = new AttributedString(text);
-    	    as.addAttribute(TextAttribute.FONT, new Font(font, style, size));
+    	    as.addAttribute(TextAttribute.FONT, font.deriveFont(style, size));
     	    if(strikethrough)	as.addAttribute(TextAttribute.STRIKETHROUGH,TextAttribute.STRIKETHROUGH_ON);
     	    if(underline)		as.addAttribute(TextAttribute.UNDERLINE,TextAttribute.UNDERLINE_ON);
     	    Graphics2D g = getGraphics();

--- a/source/java/src/org/lucee/extension/image/MarpleCaptcha.java
+++ b/source/java/src/org/lucee/extension/image/MarpleCaptcha.java
@@ -59,6 +59,10 @@ public class MarpleCaptcha extends AbstractCaptcha {
 	
 	@Override
 	public Font getFont(String font, Font defaultValue) {
-		return FontUtil.getFont(font,defaultValue);
+		try {
+			return FontUtil.getFont(font,defaultValue);
+		} catch(PageException e){
+			return Font.decode(font);
+		}
 	}
 }

--- a/source/java/src/org/lucee/extension/image/captcha/Captcha.java
+++ b/source/java/src/org/lucee/extension/image/captcha/Captcha.java
@@ -25,6 +25,9 @@ import java.io.OutputStream;
 
 import javax.imageio.ImageIO;
 
+import lucee.runtime.exp.PageException;
+import org.lucee.extension.image.font.FontUtil;
+
 /**
  * concrete captcha implementation
  */
@@ -38,7 +41,11 @@ public final class Captcha extends AbstractCaptcha {
 
 	@Override
 	public Font getFont(String font, Font defaultValue) {
-		return Font.decode(font);
+		try {
+			return FontUtil.getFont(font,defaultValue);
+		} catch(PageException e){
+			return Font.decode(font);
+		}
 	}
 
 	/**


### PR DESCRIPTION
Hi there!
I wanted to be able to use a custom TTF (font) file for writing text into an image. Therefor, I updated this extension to allow having a filepath to a ttf file in the "font" argument of function imageDrawText().
Please see code.
Unfortunately, I have not bee able to test it, as I saw no option for building the lex extension... Did I mis something here?
Kind regards, Paul Klinkenberg