### PR TITLE
Improve the LDEV-3931 fix

### DIFF
--- a/source/java/src/org/lucee/extension/image/Img.java
+++ b/source/java/src/org/lucee/extension/image/Img.java
@@ -88,16 +88,10 @@ public class Img {
 
 	public Img(java.io.File file) {
 		if (!file.exists()) throw new IllegalArgumentException("Input file not found.");
-		FileInputStream fis = null;
 		try {
-			fis = new FileInputStream(file);
-			createBufferedImage(fis);
+			createBufferedImage(new FileInputStream(file));
 		}
-		catch (Exception e) {
-		}
-		finally {
-			Util.closeEL((java.io.InputStream) fis);
-		}
+		catch (Exception e) {}
 	}
 
 	public Img(java.io.InputStream InputStream) {
@@ -588,10 +582,12 @@ public class Img {
 				stream.close();
 			}
 
-			input.close();
 		}
 		catch (Exception e) {
 			// e.printStackTrace();
+		}
+		finally {
+			Util.closeEL(input);
 		}
 	}
 

--- a/source/java/src/org/lucee/extension/image/coder/JRECoder.java
+++ b/source/java/src/org/lucee/extension/image/coder/JRECoder.java
@@ -109,7 +109,7 @@ class JRECoder extends Coder {
 		}
 
 		try {
-			BufferedImage bi = JAIUtil.read(is = res.getInputStream(), format);
+			BufferedImage bi = JAIUtil.read(is = res.getInputStream(), format); // TODO use JAIUtil.read(Resource); with   the locking issue on that method
 			if (bi != null) return bi;
 		}
 		catch (Exception e) {
@@ -120,7 +120,7 @@ class JRECoder extends Coder {
 			}
 			throw CFMLEngineFactory.getInstance().getExceptionUtil().toIOException(e);
 		}
-		finally {
+		finally { // this finally block should be removed when the reverting back to use JAIUtil.read(Resource);
 			Util.closeEL(is);
 		}
 		return null;


### PR DESCRIPTION
https://luceeserver.atlassian.net/browse/LDEV-3931

Improved to close the stream only once as per the first conversation here https://github.com/lucee/extension-image/commit/48ffe161f187def3adad0ef5f469723dfd70b5af

**TODO:**  still have to add solution to use `JAIUtil.read(Resource);` with addressing the locking issue on that method itself.
@michaeloffner can you please review the changes and please assist me to solve the locking issue in `JAIUtil.read(Resource)`

I can confirm the file locking happened on `JAIUtil.read(resource)` on getAsBufferedImage(create("fileload", res.getAbsolutePath())) line https://github.com/lucee/extension-image/blob/a57c355c0fb9efed0cf5ead206a715023f0d8a84/source/java/src/org/lucee/extension/image/JAIUtil.java#L85